### PR TITLE
Config changes necessary to use official traefik chart

### DIFF
--- a/yggdrasil/services/ingress/ingress.yaml
+++ b/yggdrasil/services/ingress/ingress.yaml
@@ -1,25 +1,21 @@
 # serviceDomain: {{ .Values.fqdn }}
 
-image:
-  name: traefik
-  tag: "v2.4.6"
-  pullPolicy: IfNotPresent
+dashboardRoute:
+  host: ingress.{{ .Values.ingressDomain }}
 
-# These will override the name that is used for all resources.
-# The name defaults to .Chart.Name and the fullname defaults to .Release.Name
-nameOverride: ""
-fullnameOverride: ""
+traefik:
+  ingressClass:
+    fallbackApiVersion: "v1"
 
-# Configure ports. A service is only created if the port config has a serviceType
-ports:
-  traefik:
-    port: 8080
-    protocol: TCP
-  web:
-    serviceType: NodePort
-    port: 80
-    nodePort: 32286
-    protocol: TCP
+  service:
+    enabled: true
+    type: LoadBalancer
+#    type: NodePort
+    spec: {}
+#      loadBalancerIP: 172.18.0.19
 
-serviceAccount:
-  name: ""
+#  ports:
+#    web:
+#      nodePort: 32080
+#    websecure:
+#      nodePort: 32443

--- a/yggdrasil/templates/ingress.yaml
+++ b/yggdrasil/templates/ingress.yaml
@@ -15,7 +15,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  ingressClassName: "mukube-ingress"
+  ingressClassName: "ingress-traefik"
   rules:
     {{- range $name, $config := .ingress }}
     - host: {{ printf "%s.%s" $config.subDomain $root.Values.ingressDomain | quote }}


### PR DESCRIPTION
The Ingress chart has been changed to depend on the official Traefik chart.
This is the config changes necessary to configure the official chart